### PR TITLE
Patch react-overlays to use KeyboardEvent.key

### DIFF
--- a/patches/react-overlays+0.9.3.patch
+++ b/patches/react-overlays+0.9.3.patch
@@ -1,0 +1,35 @@
+diff --git a/node_modules/react-overlays/lib/Modal.js b/node_modules/react-overlays/lib/Modal.js
+index 9fbba3b..c876341 100644
+--- a/node_modules/react-overlays/lib/Modal.js
++++ b/node_modules/react-overlays/lib/Modal.js
+@@ -576,7 +576,7 @@ var _initialiseProps = function _initialiseProps() {
+   };
+ 
+   this.handleDocumentKeyDown = function (e) {
+-    if (_this2.props.keyboard && e.keyCode === 27 && _this2.isTopModal()) {
++    if (_this2.props.keyboard && (e.keyCode === 27 || e.key === 'Escape') && _this2.isTopModal()) {
+       if (_this2.props.onEscapeKeyDown) {
+         _this2.props.onEscapeKeyDown(e);
+       }
+@@ -586,7 +586,7 @@ var _initialiseProps = function _initialiseProps() {
+   };
+ 
+   this.handleDocumentKeyUp = function (e) {
+-    if (_this2.props.keyboard && e.keyCode === 27 && _this2.isTopModal()) {
++    if (_this2.props.keyboard && (e.keyCode === 27 || e.key === 'Escape') && _this2.isTopModal()) {
+       if (_this2.props.onEscapeKeyUp) {
+         _this2.props.onEscapeKeyUp(e);
+       }
+diff --git a/node_modules/react-overlays/lib/RootCloseWrapper.js b/node_modules/react-overlays/lib/RootCloseWrapper.js
+index 683e1cf..c561092 100644
+--- a/node_modules/react-overlays/lib/RootCloseWrapper.js
++++ b/node_modules/react-overlays/lib/RootCloseWrapper.js
+@@ -115,7 +115,7 @@ var RootCloseWrapper = function (_React$Component) {
+         return;
+       }
+ 
+-      if (e.keyCode === escapeKeyCode && _this.props.onRootClose) {
++      if ((e.keyCode === escapeKeyCode || e.key === 'Escape') && _this.props.onRootClose) {
+         _this.props.onRootClose(e);
+       }
+     };

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -81,6 +81,36 @@ describe('<Modal>', () => {
     userEvent.click(button);
   });
 
+  it('Should close the modal when the escape key is pressed with keyboard=true', async () => {
+    const handleHide = sinon.spy();
+
+    render(
+      <Modal show onHide={handleHide} keyboard>
+        <Modal.Header closeButton />
+        <strong>Message</strong>
+      </Modal>
+    );
+
+    await userEvent.keyboard('{escape}');
+
+    assert.ok(handleHide.called);
+  });
+
+  it('Should not close the modal when the escape key is pressed with keyboard=false', async () => {
+    const handleHide = sinon.spy();
+
+    render(
+      <Modal show onHide={handleHide} keyboard={false}>
+        <Modal.Header closeButton />
+        <strong>Message</strong>
+      </Modal>
+    );
+
+    await userEvent.keyboard('{escape}');
+
+    assert.ok(!handleHide.called);
+  });
+
   it('Should pass className to the dialog', () => {
     const noOp = () => {};
     let instance;


### PR DESCRIPTION
#### Summary
`KeyboardEvent.keyCode` has been deprecated for years now, and the latest version of `@testing-library/user-event` doesn't support it. We need to add support for `KeyboardEvent.key` to be testable in Testing Library.

I made this same change in #4 for React Bootstrap itself, but it turns out it's also needed in React Overlays as well.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64382
https://mattermost.atlassian.net/browse/MM-64384
