### PR TITLE
MM-69835 Replace legacy context API with modern one

### DIFF
--- a/src/ControlLabel.js
+++ b/src/ControlLabel.js
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import warning from 'warning';
 
+import FormGroupContext from './FormGroupContext';
 import { bsClass, getClassSet, splitBsProps } from './utils/bootstrapUtils';
 
 const propTypes = {
@@ -17,13 +18,9 @@ const defaultProps = {
   srOnly: false
 };
 
-const contextTypes = {
-  $bs_formGroup: PropTypes.object
-};
-
 class ControlLabel extends React.Component {
   render() {
-    const formGroup = this.context.$bs_formGroup;
+    const formGroup = this.context;
     const controlId = formGroup && formGroup.controlId;
 
     const { htmlFor = controlId, srOnly, className, ...props } = this.props;
@@ -51,6 +48,6 @@ class ControlLabel extends React.Component {
 
 ControlLabel.propTypes = propTypes;
 ControlLabel.defaultProps = defaultProps;
-ControlLabel.contextTypes = contextTypes;
+ControlLabel.contextType = FormGroupContext;
 
 export default bsClass('control-label', ControlLabel);

--- a/src/FormControl.js
+++ b/src/FormControl.js
@@ -6,6 +6,7 @@ import warning from 'warning';
 
 import FormControlFeedback from './FormControlFeedback';
 import FormControlStatic from './FormControlStatic';
+import FormGroupContext from './FormGroupContext';
 import {
   prefix,
   bsClass,
@@ -39,13 +40,9 @@ const defaultProps = {
   componentClass: 'input'
 };
 
-const contextTypes = {
-  $bs_formGroup: PropTypes.object
-};
-
 class FormControl extends React.Component {
   render() {
-    const formGroup = this.context.$bs_formGroup;
+    const formGroup = this.context;
     const controlId = formGroup && formGroup.controlId;
 
     const {
@@ -92,7 +89,7 @@ class FormControl extends React.Component {
 
 FormControl.propTypes = propTypes;
 FormControl.defaultProps = defaultProps;
-FormControl.contextTypes = contextTypes;
+FormControl.contextType = FormGroupContext;
 
 FormControl.Feedback = FormControlFeedback;
 FormControl.Static = FormControlStatic;

--- a/src/FormControlFeedback.js
+++ b/src/FormControlFeedback.js
@@ -1,16 +1,12 @@
 import classNames from 'classnames';
 import React from 'react';
-import PropTypes from 'prop-types';
 
+import FormGroupContext from './FormGroupContext';
 import Glyphicon from './Glyphicon';
 import { bsClass, getClassSet, splitBsProps } from './utils/bootstrapUtils';
 
 const defaultProps = {
   bsRole: 'feedback'
-};
-
-const contextTypes = {
-  $bs_formGroup: PropTypes.object
 };
 
 class FormControlFeedback extends React.Component {
@@ -50,7 +46,7 @@ class FormControlFeedback extends React.Component {
 
     if (!children) {
       return this.renderDefaultFeedback(
-        this.context.$bs_formGroup,
+        this.context,
         className,
         classes,
         elementProps
@@ -66,6 +62,6 @@ class FormControlFeedback extends React.Component {
 }
 
 FormControlFeedback.defaultProps = defaultProps;
-FormControlFeedback.contextTypes = contextTypes;
+FormControlFeedback.contextType = FormGroupContext;
 
 export default bsClass('form-control-feedback', FormControlFeedback);

--- a/src/FormGroup.js
+++ b/src/FormGroup.js
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import FormGroupContext from './FormGroupContext';
 import {
   bsClass,
   bsSizes,
@@ -19,22 +20,7 @@ const propTypes = {
   validationState: PropTypes.oneOf(['success', 'warning', 'error', null])
 };
 
-const childContextTypes = {
-  $bs_formGroup: PropTypes.object.isRequired
-};
-
 class FormGroup extends React.Component {
-  getChildContext() {
-    const { controlId, validationState } = this.props;
-
-    return {
-      $bs_formGroup: {
-        controlId,
-        validationState
-      }
-    };
-  }
-
   hasFeedback(children) {
     return ValidComponentChildren.some(
       children,
@@ -57,15 +43,18 @@ class FormGroup extends React.Component {
     }
 
     return (
-      <div {...elementProps} className={classNames(className, classes)}>
-        {children}
-      </div>
+      <FormGroupContext.Provider
+        value={{ controlId: this.props.controlId, validationState }}
+      >
+        <div {...elementProps} className={classNames(className, classes)}>
+          {children}
+        </div>
+      </FormGroupContext.Provider>
     );
   }
 }
 
 FormGroup.propTypes = propTypes;
-FormGroup.childContextTypes = childContextTypes;
 
 export default bsClass(
   'form-group',

--- a/src/FormGroupContext.js
+++ b/src/FormGroupContext.js
@@ -1,0 +1,6 @@
+import React from 'react';
+
+const FormGroupContext = React.createContext(undefined);
+FormGroupContext.displayName = 'FormGroupContext';
+
+export default FormGroupContext;

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -12,6 +12,7 @@ import elementType from 'prop-types-extra/lib/elementType';
 
 import Fade from './Fade';
 import Body from './ModalBody';
+import ModalContext from './ModalContext';
 import ModalDialog from './ModalDialog';
 import Footer from './ModalFooter';
 import Header from './ModalHeader';
@@ -128,12 +129,6 @@ const defaultProps = {
   dialogComponentClass: ModalDialog
 };
 
-const childContextTypes = {
-  $bs_modal: PropTypes.shape({
-    onHide: PropTypes.func
-  })
-};
-
 /* eslint-disable no-use-before-define, react/no-multi-comp */
 function DialogTransition(props) {
   return <Fade {...props} timeout={Modal.TRANSITION_DURATION} />;
@@ -157,14 +152,6 @@ class Modal extends React.Component {
 
     this.state = {
       style: {}
-    };
-  }
-
-  getChildContext() {
-    return {
-      $bs_modal: {
-        onHide: this.props.onHide
-      }
     };
   }
 
@@ -257,39 +244,40 @@ class Modal extends React.Component {
     const inClassName = show && !animation && 'in';
 
     return (
-      <BaseModal
-        {...baseModalProps}
-        ref={this.setModalRef}
-        show={show}
-        containerClassName={prefix(props, 'open')}
-        transition={animation ? DialogTransition : undefined}
-        backdrop={backdrop}
-        backdropTransition={animation ? BackdropTransition : undefined}
-        backdropClassName={classNames(
-          prefix(props, 'backdrop'),
-          backdropClassName,
-          inClassName
-        )}
-        onEntering={createChainedFunction(onEntering, this.handleEntering)}
-        onExited={createChainedFunction(onExited, this.handleExited)}
-      >
-        <Dialog
-          {...dialogProps}
-          style={{ ...this.state.style, ...style }}
-          className={classNames(className, inClassName)}
-          onClick={backdrop === true ? this.handleDialogClick : null}
-          handleDialogMouseDown={this.handleDialogMouseDown}
+      <ModalContext.Provider value={{ onHide: this.props.onHide }}>
+        <BaseModal
+          {...baseModalProps}
+          ref={this.setModalRef}
+          show={show}
+          containerClassName={prefix(props, 'open')}
+          transition={animation ? DialogTransition : undefined}
+          backdrop={backdrop}
+          backdropTransition={animation ? BackdropTransition : undefined}
+          backdropClassName={classNames(
+            prefix(props, 'backdrop'),
+            backdropClassName,
+            inClassName
+          )}
+          onEntering={createChainedFunction(onEntering, this.handleEntering)}
+          onExited={createChainedFunction(onExited, this.handleExited)}
         >
-          {children}
-        </Dialog>
-      </BaseModal>
+          <Dialog
+            {...dialogProps}
+            style={{ ...this.state.style, ...style }}
+            className={classNames(className, inClassName)}
+            onClick={backdrop === true ? this.handleDialogClick : null}
+            handleDialogMouseDown={this.handleDialogMouseDown}
+          >
+            {children}
+          </Dialog>
+        </BaseModal>
+      </ModalContext.Provider>
     );
   }
 }
 
 Modal.propTypes = propTypes;
 Modal.defaultProps = defaultProps;
-Modal.childContextTypes = childContextTypes;
 
 Modal.Body = Body;
 Modal.Header = Header;

--- a/src/ModalContext.js
+++ b/src/ModalContext.js
@@ -1,0 +1,6 @@
+import React from 'react';
+
+const ModalContext = React.createContext(undefined);
+ModalContext.displayName = 'ModalContext';
+
+export default ModalContext;

--- a/src/ModalHeader.js
+++ b/src/ModalHeader.js
@@ -5,6 +5,7 @@ import React from 'react';
 import { bsClass, getClassSet, splitBsProps } from './utils/bootstrapUtils';
 import createChainedFunction from './utils/createChainedFunction';
 import CloseButton from './CloseButton';
+import ModalContext from './ModalContext';
 
 // TODO: `aria-label` should be `closeLabel`.
 
@@ -34,12 +35,6 @@ const defaultProps = {
   closeButton: false
 };
 
-const contextTypes = {
-  $bs_modal: PropTypes.shape({
-    onHide: PropTypes.func
-  })
-};
-
 class ModalHeader extends React.Component {
   render() {
     const {
@@ -51,7 +46,7 @@ class ModalHeader extends React.Component {
       ...props
     } = this.props;
 
-    const modal = this.context.$bs_modal;
+    const modal = this.context;
 
     const [bsProps, elementProps] = splitBsProps(props);
 
@@ -74,6 +69,6 @@ class ModalHeader extends React.Component {
 
 ModalHeader.propTypes = propTypes;
 ModalHeader.defaultProps = defaultProps;
-ModalHeader.contextTypes = contextTypes;
+ModalHeader.contextType = ModalContext;
 
 export default bsClass('modal-header', ModalHeader);

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -1,10 +1,12 @@
 import classNames from 'classnames';
-import React, { cloneElement } from 'react';
+import React, { cloneElement, useContext } from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import all from 'prop-types-extra/lib/all';
 import warning from 'warning';
 
+import NavbarContext from './NavbarContext';
+import TabContainerContext from './TabContainerContext';
 import {
   bsClass,
   bsStyles,
@@ -95,20 +97,6 @@ const defaultProps = {
   stacked: false
 };
 
-const contextTypes = {
-  $bs_navbar: PropTypes.shape({
-    bsClass: PropTypes.string,
-    onSelect: PropTypes.func
-  }),
-
-  $bs_tabContainer: PropTypes.shape({
-    activeKey: PropTypes.any,
-    onSelect: PropTypes.func.isRequired,
-    getTabId: PropTypes.func.isRequired,
-    getPaneId: PropTypes.func.isRequired
-  })
-};
-
 class Nav extends React.Component {
   componentDidUpdate() {
     if (!this._needsRefocus) {
@@ -138,7 +126,7 @@ class Nav extends React.Component {
   }
 
   getActiveProps() {
-    const tabContainer = this.context.$bs_tabContainer;
+    const tabContainer = this.props.tabContainerContext;
 
     if (tabContainer) {
       warning(
@@ -280,10 +268,12 @@ class Nav extends React.Component {
       pullLeft,
       className,
       children,
+      navbarContext,
+      tabContainerContext,
       ...props
     } = this.props;
 
-    const tabContainer = this.context.$bs_tabContainer;
+    const tabContainer = tabContainerContext;
     const role = propsRole || (tabContainer ? 'tablist' : null);
 
     const { activeKey, activeHref } = this.getActiveProps();
@@ -298,12 +288,12 @@ class Nav extends React.Component {
       [prefix(bsProps, 'justified')]: justified
     };
 
-    const navbar = propsNavbar != null ? propsNavbar : this.context.$bs_navbar;
+    const navbar = propsNavbar != null ? propsNavbar : navbarContext;
     let pullLeftClassName;
     let pullRightClassName;
 
     if (navbar) {
-      const navbarProps = this.context.$bs_navbar || { bsClass: 'navbar' };
+      const navbarProps = navbarContext || { bsClass: 'navbar' };
 
       classes[prefix(navbarProps, 'nav')] = true;
 
@@ -353,6 +343,18 @@ class Nav extends React.Component {
 
 Nav.propTypes = propTypes;
 Nav.defaultProps = defaultProps;
-Nav.contextTypes = contextTypes;
 
-export default bsClass('nav', bsStyles(['tabs', 'pills'], Nav));
+function NavWithContext(props) {
+  const navbarContext = useContext(NavbarContext);
+  const tabContainerContext = useContext(TabContainerContext);
+
+  return (
+    <Nav
+      {...props}
+      navbarContext={navbarContext}
+      tabContainerContext={tabContainerContext}
+    />
+  );
+}
+
+export default bsClass('nav', bsStyles(['tabs', 'pills'], NavWithContext));

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -344,17 +344,19 @@ class Nav extends React.Component {
 Nav.propTypes = propTypes;
 Nav.defaultProps = defaultProps;
 
-function NavWithContext(props) {
+const NavWithContext = React.forwardRef((props, ref) => {
   const navbarContext = useContext(NavbarContext);
   const tabContainerContext = useContext(TabContainerContext);
 
   return (
     <Nav
+      ref={ref}
       {...props}
       navbarContext={navbarContext}
       tabContainerContext={tabContainerContext}
     />
   );
-}
+});
+NavWithContext.displayName = 'NavWithContext';
 
 export default bsClass('nav', bsStyles(['tabs', 'pills'], NavWithContext));

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -2,7 +2,7 @@
 /* eslint-disable react/no-multi-comp */
 
 import classNames from 'classnames';
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import elementType from 'prop-types-extra/lib/elementType';
 import uncontrollable from 'uncontrollable';
@@ -10,6 +10,7 @@ import uncontrollable from 'uncontrollable';
 import Grid from './Grid';
 import NavbarBrand from './NavbarBrand';
 import NavbarCollapse from './NavbarCollapse';
+import NavbarContext from './NavbarContext';
 import NavbarHeader from './NavbarHeader';
 import NavbarToggle from './NavbarToggle';
 import {
@@ -109,37 +110,12 @@ const defaultProps = {
   collapseOnSelect: false
 };
 
-const childContextTypes = {
-  $bs_navbar: PropTypes.shape({
-    bsClass: PropTypes.string,
-    expanded: PropTypes.bool,
-    onToggle: PropTypes.func.isRequired,
-    onSelect: PropTypes.func
-  })
-};
-
 class Navbar extends React.Component {
   constructor(props, context) {
     super(props, context);
 
     this.handleToggle = this.handleToggle.bind(this);
     this.handleCollapse = this.handleCollapse.bind(this);
-  }
-
-  getChildContext() {
-    const { bsClass, expanded, onSelect, collapseOnSelect } = this.props;
-
-    return {
-      $bs_navbar: {
-        bsClass,
-        expanded,
-        onToggle: this.handleToggle,
-        onSelect: createChainedFunction(
-          onSelect,
-          collapseOnSelect ? this.handleCollapse : null
-        )
-      }
-    };
   }
 
   handleCollapse() {
@@ -194,43 +170,57 @@ class Navbar extends React.Component {
       [prefix(bsProps, 'static-top')]: staticTop
     };
 
+    const { bsClass, expanded, onSelect, collapseOnSelect } = this.props;
+
+    const navbarContext = {
+      bsClass,
+      expanded,
+      onToggle: this.handleToggle,
+      onSelect: createChainedFunction(
+        onSelect,
+        collapseOnSelect ? this.handleCollapse : null
+      )
+    };
+
     return (
-      <Component {...elementProps} className={classNames(className, classes)}>
-        <Grid fluid={fluid}>{children}</Grid>
-      </Component>
+      <NavbarContext.Provider value={navbarContext}>
+        <Component {...elementProps} className={classNames(className, classes)}>
+          <Grid fluid={fluid}>{children}</Grid>
+        </Component>
+      </NavbarContext.Provider>
     );
   }
 }
 
 Navbar.propTypes = propTypes;
 Navbar.defaultProps = defaultProps;
-Navbar.childContextTypes = childContextTypes;
 
 setBsClass('navbar', Navbar);
 
 const UncontrollableNavbar = uncontrollable(Navbar, { expanded: 'onToggle' });
 
 function createSimpleWrapper(tag, suffix, displayName) {
-  const Wrapper = (
-    {
-      componentClass: Component = tag,
-      className,
-      pullRight = false,
-      pullLeft = false,
-      ...props
-    },
-    { $bs_navbar: navbarProps = { bsClass: 'navbar' } }
-  ) => (
-    <Component
-      {...props}
-      className={classNames(
-        className,
-        prefix(navbarProps, suffix),
-        pullRight && prefix(navbarProps, 'right'),
-        pullLeft && prefix(navbarProps, 'left')
-      )}
-    />
-  );
+  const Wrapper = ({
+    componentClass: Component = tag,
+    className,
+    pullRight = false,
+    pullLeft = false,
+    ...props
+  }) => {
+    const navbarProps = useContext(NavbarContext) || { bsClass: 'navbar' };
+
+    return (
+      <Component
+        {...props}
+        className={classNames(
+          className,
+          prefix(navbarProps, suffix),
+          pullRight && prefix(navbarProps, 'right'),
+          pullLeft && prefix(navbarProps, 'left')
+        )}
+      />
+    );
+  };
 
   Wrapper.displayName = displayName;
 
@@ -238,12 +228,6 @@ function createSimpleWrapper(tag, suffix, displayName) {
     componentClass: elementType,
     pullRight: PropTypes.bool,
     pullLeft: PropTypes.bool
-  };
-
-  Wrapper.contextTypes = {
-    $bs_navbar: PropTypes.shape({
-      bsClass: PropTypes.string
-    })
   };
 
   return Wrapper;

--- a/src/NavbarBrand.js
+++ b/src/NavbarBrand.js
@@ -1,19 +1,13 @@
 import classNames from 'classnames';
 import React from 'react';
-import PropTypes from 'prop-types';
 
+import NavbarContext from './NavbarContext';
 import { prefix } from './utils/bootstrapUtils';
-
-const contextTypes = {
-  $bs_navbar: PropTypes.shape({
-    bsClass: PropTypes.string
-  })
-};
 
 class NavbarBrand extends React.Component {
   render() {
     const { className, children, ...props } = this.props;
-    const navbarProps = this.context.$bs_navbar || { bsClass: 'navbar' };
+    const navbarProps = this.context || { bsClass: 'navbar' };
 
     const bsClassName = prefix(navbarProps, 'brand');
 
@@ -31,6 +25,6 @@ class NavbarBrand extends React.Component {
   }
 }
 
-NavbarBrand.contextTypes = contextTypes;
+NavbarBrand.contextType = NavbarContext;
 
 export default NavbarBrand;

--- a/src/NavbarCollapse.js
+++ b/src/NavbarCollapse.js
@@ -1,20 +1,13 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import Collapse from './Collapse';
+import NavbarContext from './NavbarContext';
 import { prefix } from './utils/bootstrapUtils';
-
-const contextTypes = {
-  $bs_navbar: PropTypes.shape({
-    bsClass: PropTypes.string,
-    expanded: PropTypes.bool
-  })
-};
 
 class NavbarCollapse extends React.Component {
   render() {
     const { children, ...props } = this.props;
-    const navbarProps = this.context.$bs_navbar || { bsClass: 'navbar' };
+    const navbarProps = this.context || { bsClass: 'navbar' };
 
     const bsClassName = prefix(navbarProps, 'collapse');
 
@@ -26,6 +19,6 @@ class NavbarCollapse extends React.Component {
   }
 }
 
-NavbarCollapse.contextTypes = contextTypes;
+NavbarCollapse.contextType = NavbarContext;
 
 export default NavbarCollapse;

--- a/src/NavbarContext.js
+++ b/src/NavbarContext.js
@@ -1,0 +1,6 @@
+import React from 'react';
+
+const NavbarContext = React.createContext(undefined);
+NavbarContext.displayName = 'NavbarContext';
+
+export default NavbarContext;

--- a/src/NavbarHeader.js
+++ b/src/NavbarHeader.js
@@ -1,19 +1,13 @@
 import classNames from 'classnames';
 import React from 'react';
-import PropTypes from 'prop-types';
 
+import NavbarContext from './NavbarContext';
 import { prefix } from './utils/bootstrapUtils';
-
-const contextTypes = {
-  $bs_navbar: PropTypes.shape({
-    bsClass: PropTypes.string
-  })
-};
 
 class NavbarHeader extends React.Component {
   render() {
     const { className, ...props } = this.props;
-    const navbarProps = this.context.$bs_navbar || { bsClass: 'navbar' };
+    const navbarProps = this.context || { bsClass: 'navbar' };
 
     const bsClassName = prefix(navbarProps, 'header');
 
@@ -21,6 +15,6 @@ class NavbarHeader extends React.Component {
   }
 }
 
-NavbarHeader.contextTypes = contextTypes;
+NavbarHeader.contextType = NavbarContext;
 
 export default NavbarHeader;

--- a/src/NavbarToggle.js
+++ b/src/NavbarToggle.js
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import NavbarContext from './NavbarContext';
 import { prefix } from './utils/bootstrapUtils';
 import createChainedFunction from './utils/createChainedFunction';
 
@@ -13,18 +14,10 @@ const propTypes = {
   children: PropTypes.node
 };
 
-const contextTypes = {
-  $bs_navbar: PropTypes.shape({
-    bsClass: PropTypes.string,
-    expanded: PropTypes.bool,
-    onToggle: PropTypes.func.isRequired
-  })
-};
-
 class NavbarToggle extends React.Component {
   render() {
     const { onClick, className, children, ...props } = this.props;
-    const navbarProps = this.context.$bs_navbar || { bsClass: 'navbar' };
+    const navbarProps = this.context || { bsClass: 'navbar' };
 
     const buttonProps = {
       type: 'button',
@@ -53,6 +46,6 @@ class NavbarToggle extends React.Component {
 }
 
 NavbarToggle.propTypes = propTypes;
-NavbarToggle.contextTypes = contextTypes;
+NavbarToggle.contextType = NavbarContext;
 
 export default NavbarToggle;

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -12,6 +12,8 @@ import {
 } from './utils/bootstrapUtils';
 import { State, Style } from './utils/StyleConfig';
 import Body from './PanelBody';
+import PanelContext from './PanelContext';
+import PanelGroupContext from './PanelGroupContext';
 import Heading from './PanelHeading';
 import Title from './PanelTitle';
 import Footer from './PanelFooter';
@@ -45,53 +47,9 @@ const propTypes = {
   id: PropTypes.string
 };
 
-const contextTypes = {
-  $bs_panelGroup: PropTypes.shape({
-    getId: PropTypes.func,
-    activeKey: PropTypes.any,
-    onToggle: PropTypes.func
-  })
-};
-
-const childContextTypes = {
-  $bs_panel: PropTypes.shape({
-    headingId: PropTypes.string,
-    bodyId: PropTypes.string,
-    bsClass: PropTypes.string,
-    onToggle: PropTypes.func,
-    expanded: PropTypes.bool
-  })
-};
-
 class Panel extends React.Component {
-  getChildContext() {
-    const { eventKey, id } = this.props;
-    const idKey = eventKey == null ? id : eventKey;
-
-    let ids;
-
-    if (idKey !== null) {
-      const panelGroup = this.context.$bs_panelGroup;
-      const getId = (panelGroup && panelGroup.getId) || defaultGetId;
-
-      ids = {
-        headingId: getId(idKey, 'heading'),
-        bodyId: getId(idKey, 'body')
-      };
-    }
-
-    return {
-      $bs_panel: {
-        ...ids,
-        bsClass: this.props.bsClass,
-        expanded: this.getExpanded(),
-        onToggle: this.handleToggle
-      }
-    };
-  }
-
   getExpanded() {
-    const panelGroup = this.context.$bs_panelGroup;
+    const panelGroup = this.context;
 
     if (panelGroup && has.call(panelGroup, 'activeKey')) {
       warning(
@@ -108,7 +66,7 @@ class Panel extends React.Component {
   }
 
   handleToggle = e => {
-    const panelGroup = this.context.$bs_panelGroup;
+    const panelGroup = this.context;
     const expanded = !this.getExpanded();
 
     if (panelGroup && panelGroup.onToggle) {
@@ -126,18 +84,41 @@ class Panel extends React.Component {
       'expanded'
     ]);
 
+    const { eventKey, id } = this.props;
+    const idKey = eventKey == null ? id : eventKey;
+
+    let ids;
+
+    if (idKey !== null) {
+      const panelGroup = this.context;
+      const getId = (panelGroup && panelGroup.getId) || defaultGetId;
+
+      ids = {
+        headingId: getId(idKey, 'heading'),
+        bodyId: getId(idKey, 'body')
+      };
+    }
+
+    const panelContext = {
+      ...ids,
+      bsClass: this.props.bsClass,
+      expanded: this.getExpanded(),
+      onToggle: this.handleToggle
+    };
+
     return (
-      <div {...props} className={classNames(className, getClassSet(bsProps))}>
-        {children}
-      </div>
+      <PanelContext.Provider value={panelContext}>
+        <div {...props} className={classNames(className, getClassSet(bsProps))}>
+          {children}
+        </div>
+      </PanelContext.Provider>
     );
   }
 }
 
 Panel.propTypes = propTypes;
 
-Panel.contextTypes = contextTypes;
-Panel.childContextTypes = childContextTypes;
+Panel.contextType = PanelGroupContext;
 
 const UncontrolledPanel = uncontrollable(
   bsClass(

--- a/src/PanelBody.js
+++ b/src/PanelBody.js
@@ -3,6 +3,7 @@ import React from 'react';
 import cn from 'classnames';
 import { prefix, splitBsPropsAndOmit, bsClass } from './utils/bootstrapUtils';
 import PanelCollapse from './PanelCollapse';
+import PanelContext from './PanelContext';
 
 const propTypes = {
   /**
@@ -23,16 +24,10 @@ const defaultProps = {
   collapsible: false
 };
 
-const contextTypes = {
-  $bs_panel: PropTypes.shape({
-    bsClass: PropTypes.string
-  })
-};
-
 class PanelBody extends React.Component {
   render() {
     const { children, className, collapsible } = this.props;
-    const { bsClass: _bsClass } = this.context.$bs_panel || {};
+    const { bsClass: _bsClass } = this.context || {};
 
     const [bsProps, elementProps] = splitBsPropsAndOmit(this.props, [
       'collapsible'
@@ -55,6 +50,6 @@ class PanelBody extends React.Component {
 
 PanelBody.propTypes = propTypes;
 PanelBody.defaultProps = defaultProps;
-PanelBody.contextTypes = contextTypes;
+PanelBody.contextType = PanelContext;
 
 export default bsClass('panel', PanelBody);

--- a/src/PanelCollapse.js
+++ b/src/PanelCollapse.js
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { prefix, splitBsProps, bsClass } from './utils/bootstrapUtils';
 import Collapse from './Collapse';
+import PanelContext from './PanelContext';
 
 const propTypes = {
   /**
@@ -31,20 +32,11 @@ const propTypes = {
   onExited: PropTypes.func
 };
 
-const contextTypes = {
-  $bs_panel: PropTypes.shape({
-    headingId: PropTypes.string,
-    bodyId: PropTypes.string,
-    bsClass: PropTypes.string,
-    expanded: PropTypes.bool
-  })
-};
-
 class PanelCollapse extends React.Component {
   render() {
     const { children } = this.props;
     const { headingId, bodyId, bsClass: _bsClass, expanded } =
-      this.context.$bs_panel || {};
+      this.context || {};
 
     const [bsProps, props] = splitBsProps(this.props);
 
@@ -65,6 +57,6 @@ class PanelCollapse extends React.Component {
 }
 
 PanelCollapse.propTypes = propTypes;
-PanelCollapse.contextTypes = contextTypes;
+PanelCollapse.contextType = PanelContext;
 
 export default bsClass('panel', PanelCollapse);

--- a/src/PanelContext.js
+++ b/src/PanelContext.js
@@ -1,0 +1,6 @@
+import React from 'react';
+
+const PanelContext = React.createContext(undefined);
+PanelContext.displayName = 'PanelContext';
+
+export default PanelContext;

--- a/src/PanelFooter.js
+++ b/src/PanelFooter.js
@@ -1,18 +1,13 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 import cn from 'classnames';
-import { prefix, bsClass, splitBsProps } from './utils/bootstrapUtils';
 
-const contextTypes = {
-  $bs_panel: PropTypes.shape({
-    bsClass: PropTypes.string
-  })
-};
+import PanelContext from './PanelContext';
+import { prefix, bsClass, splitBsProps } from './utils/bootstrapUtils';
 
 class PanelFooter extends React.Component {
   render() {
     let { children, className } = this.props;
-    let { bsClass: _bsClass } = this.context.$bs_panel || {};
+    let { bsClass: _bsClass } = this.context || {};
 
     const [bsProps, elementProps] = splitBsProps(this.props);
     bsProps.bsClass = _bsClass || bsProps.bsClass;
@@ -28,6 +23,6 @@ class PanelFooter extends React.Component {
   }
 }
 
-PanelFooter.contextTypes = contextTypes;
+PanelFooter.contextType = PanelContext;
 
 export default bsClass('panel', PanelFooter);

--- a/src/PanelGroup.js
+++ b/src/PanelGroup.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React, { cloneElement } from 'react';
 import uncontrollable from 'uncontrollable';
 
+import PanelGroupContext from './PanelGroupContext';
 import {
   bsClass,
   getClassSet,
@@ -56,40 +57,7 @@ const defaultProps = {
   accordion: false
 };
 
-const childContextTypes = {
-  $bs_panelGroup: PropTypes.shape({
-    getId: PropTypes.func,
-    headerRole: PropTypes.string,
-    panelRole: PropTypes.string,
-    activeKey: PropTypes.any,
-    onToggle: PropTypes.func
-  })
-};
-
 class PanelGroup extends React.Component {
-  getChildContext() {
-    const { activeKey, accordion, generateChildId, id } = this.props;
-    let getId = null;
-
-    if (accordion) {
-      getId =
-        generateChildId ||
-        ((key, type) => (id ? `${id}-${type}-${key}` : null));
-    }
-
-    return {
-      $bs_panelGroup: {
-        getId,
-        headerRole: 'tab',
-        panelRole: 'tabpanel',
-        ...(accordion && {
-          activeKey,
-          onToggle: this.handleSelect
-        })
-      }
-    };
-  }
-
   handleSelect = (key, expanded, e) => {
     if (expanded) {
       this.props.onSelect(key, e);
@@ -112,21 +80,41 @@ class PanelGroup extends React.Component {
 
     const classes = getClassSet(bsProps);
 
+    const { activeKey, generateChildId, id } = this.props;
+    let getId = null;
+
+    if (accordion) {
+      getId =
+        generateChildId ||
+        ((key, type) => (id ? `${id}-${type}-${key}` : null));
+    }
+
+    const panelGroupContext = {
+      getId,
+      headerRole: 'tab',
+      panelRole: 'tabpanel',
+      ...(accordion && {
+        activeKey,
+        onToggle: this.handleSelect
+      })
+    };
+
     return (
-      <div {...elementProps} className={classNames(className, classes)}>
-        {ValidComponentChildren.map(children, child =>
-          cloneElement(child, {
-            bsStyle: child.props.bsStyle || bsProps.bsStyle
-          })
-        )}
-      </div>
+      <PanelGroupContext.Provider value={panelGroupContext}>
+        <div {...elementProps} className={classNames(className, classes)}>
+          {ValidComponentChildren.map(children, child =>
+            cloneElement(child, {
+              bsStyle: child.props.bsStyle || bsProps.bsStyle
+            })
+          )}
+        </div>
+      </PanelGroupContext.Provider>
     );
   }
 }
 
 PanelGroup.propTypes = propTypes;
 PanelGroup.defaultProps = defaultProps;
-PanelGroup.childContextTypes = childContextTypes;
 
 export default uncontrollable(bsClass('panel-group', PanelGroup), {
   activeKey: 'onSelect'

--- a/src/PanelGroupContext.js
+++ b/src/PanelGroupContext.js
@@ -1,0 +1,6 @@
+import React from 'react';
+
+const PanelGroupContext = React.createContext(undefined);
+PanelGroupContext.displayName = 'PanelGroupContext';
+
+export default PanelGroupContext;

--- a/src/PanelHeading.js
+++ b/src/PanelHeading.js
@@ -1,8 +1,8 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 import cn from 'classnames';
 import elementType from 'react-prop-types/lib/elementType';
 
+import PanelContext from './PanelContext';
 import { prefix, bsClass, splitBsProps } from './utils/bootstrapUtils';
 
 const propTypes = {
@@ -13,13 +13,6 @@ const defaultProps = {
   componentClass: 'div'
 };
 
-const contextTypes = {
-  $bs_panel: PropTypes.shape({
-    headingId: PropTypes.string,
-    bsClass: PropTypes.string
-  })
-};
-
 class PanelHeading extends React.Component {
   render() {
     const {
@@ -28,7 +21,7 @@ class PanelHeading extends React.Component {
       componentClass: Component,
       ...props
     } = this.props;
-    const { headingId, bsClass: _bsClass } = this.context.$bs_panel || {};
+    const { headingId, bsClass: _bsClass } = this.context || {};
 
     const [bsProps, elementProps] = splitBsProps(props);
     bsProps.bsClass = _bsClass || bsProps.bsClass;
@@ -51,6 +44,6 @@ class PanelHeading extends React.Component {
 
 PanelHeading.propTypes = propTypes;
 PanelHeading.defaultProps = defaultProps;
-PanelHeading.contextTypes = contextTypes;
+PanelHeading.contextType = PanelContext;
 
 export default bsClass('panel', PanelHeading);

--- a/src/PanelTitle.js
+++ b/src/PanelTitle.js
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import elementType from 'react-prop-types/lib/elementType';
 
-import { prefix, splitBsProps, bsClass } from './utils/bootstrapUtils';
+import PanelContext from './PanelContext';
 import PanelToggle from './PanelToggle';
+import { prefix, splitBsProps, bsClass } from './utils/bootstrapUtils';
 
 const propTypes = {
   componentClass: elementType,
@@ -13,12 +14,6 @@ const propTypes = {
    * for the common use-case.
    */
   toggle: PropTypes.bool
-};
-
-const contextTypes = {
-  $bs_panel: PropTypes.shape({
-    bsClass: PropTypes.string
-  })
 };
 
 const defaultProps = {
@@ -35,7 +30,7 @@ class PanelTitle extends React.Component {
       ...props
     } = this.props;
 
-    const { bsClass: _bsClass } = this.context.$bs_panel || {};
+    const { bsClass: _bsClass } = this.context || {};
 
     const [bsProps, elementProps] = splitBsProps(props);
     bsProps.bsClass = _bsClass || bsProps.bsClass;
@@ -57,6 +52,6 @@ class PanelTitle extends React.Component {
 
 PanelTitle.propTypes = propTypes;
 PanelTitle.defaultProps = defaultProps;
-PanelTitle.contextTypes = contextTypes;
+PanelTitle.contextType = PanelContext;
 
 export default bsClass('panel', PanelTitle);

--- a/src/PanelToggle.js
+++ b/src/PanelToggle.js
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import elementType from 'react-prop-types/lib/elementType';
+
+import PanelContext from './PanelContext';
 import SafeAnchor from './SafeAnchor';
 import createChainedFunction from './utils/createChainedFunction';
 
@@ -22,14 +24,6 @@ const defaultProps = {
   componentClass: SafeAnchor
 };
 
-const contextTypes = {
-  $bs_panel: PropTypes.shape({
-    bodyId: PropTypes.string,
-    onToggle: PropTypes.func,
-    expanded: PropTypes.bool
-  })
-};
-
 class PanelToggle extends React.Component {
   constructor(...args) {
     super(...args);
@@ -38,7 +32,7 @@ class PanelToggle extends React.Component {
   }
 
   handleToggle(event) {
-    const { onToggle } = this.context.$bs_panel || {};
+    const { onToggle } = this.context || {};
 
     if (onToggle) {
       onToggle(event);
@@ -47,7 +41,7 @@ class PanelToggle extends React.Component {
 
   render() {
     const { onClick, className, componentClass, ...props } = this.props;
-    const { expanded, bodyId } = this.context.$bs_panel || {};
+    const { expanded, bodyId } = this.context || {};
     const Component = componentClass;
 
     props.onClick = createChainedFunction(onClick, this.handleToggle);
@@ -65,6 +59,6 @@ class PanelToggle extends React.Component {
 
 PanelToggle.propTypes = propTypes;
 PanelToggle.defaultProps = defaultProps;
-PanelToggle.contextTypes = contextTypes;
+PanelToggle.contextType = PanelContext;
 
 export default PanelToggle;

--- a/src/TabContainer.js
+++ b/src/TabContainer.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import uncontrollable from 'uncontrollable';
 
+import TabContainerContext from './TabContainerContext';
+
 const TAB = 'tab';
 const PANE = 'pane';
 
@@ -58,44 +60,34 @@ const propTypes = {
   activeKey: PropTypes.any
 };
 
-const childContextTypes = {
-  $bs_tabContainer: PropTypes.shape({
-    activeKey: PropTypes.any,
-    onSelect: PropTypes.func.isRequired,
-    getTabId: PropTypes.func.isRequired,
-    getPaneId: PropTypes.func.isRequired
-  })
-};
-
 class TabContainer extends React.Component {
-  getChildContext() {
+  render() {
+    const { children, ...props } = this.props;
+
     const { activeKey, onSelect, generateChildId, id } = this.props;
 
     const getId =
       generateChildId || ((key, type) => (id ? `${id}-${type}-${key}` : null));
 
-    return {
-      $bs_tabContainer: {
-        activeKey,
-        onSelect,
-        getTabId: key => getId(key, TAB),
-        getPaneId: key => getId(key, PANE)
-      }
+    const tabContainerContext = {
+      activeKey,
+      onSelect,
+      getTabId: key => getId(key, TAB),
+      getPaneId: key => getId(key, PANE)
     };
-  }
-
-  render() {
-    const { children, ...props } = this.props;
 
     delete props.generateChildId;
     delete props.onSelect;
     delete props.activeKey;
 
-    return React.cloneElement(React.Children.only(children), props);
+    return (
+      <TabContainerContext.Provider value={tabContainerContext}>
+        {React.cloneElement(React.Children.only(children), props)}
+      </TabContainerContext.Provider>
+    );
   }
 }
 
 TabContainer.propTypes = propTypes;
-TabContainer.childContextTypes = childContextTypes;
 
 export default uncontrollable(TabContainer, { activeKey: 'onSelect' });

--- a/src/TabContainerContext.js
+++ b/src/TabContainerContext.js
@@ -1,0 +1,6 @@
+import React from 'react';
+
+const TabContainerContext = React.createContext(undefined);
+TabContainerContext.displayName = 'TabContainerContext';
+
+export default TabContainerContext;

--- a/src/TabContent.js
+++ b/src/TabContent.js
@@ -3,6 +3,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import elementType from 'prop-types-extra/lib/elementType';
 
+import TabContainerContext from './TabContainerContext';
+import TabContentContext from './TabContentContext';
 import {
   bsClass as setBsClass,
   prefix,
@@ -37,25 +39,6 @@ const defaultProps = {
   unmountOnExit: false
 };
 
-const contextTypes = {
-  $bs_tabContainer: PropTypes.shape({
-    activeKey: PropTypes.any
-  })
-};
-
-const childContextTypes = {
-  $bs_tabContent: PropTypes.shape({
-    bsClass: PropTypes.string,
-    animation: PropTypes.oneOfType([PropTypes.bool, elementType]),
-    activeKey: PropTypes.any,
-    mountOnEnter: PropTypes.bool,
-    unmountOnExit: PropTypes.bool,
-    onPaneEnter: PropTypes.func.isRequired,
-    onPaneExited: PropTypes.func.isRequired,
-    exiting: PropTypes.bool.isRequired
-  })
-};
-
 class TabContent extends React.Component {
   constructor(props, context) {
     super(props, context);
@@ -72,31 +55,6 @@ class TabContent extends React.Component {
     };
   }
 
-  getChildContext() {
-    const { bsClass, animation, mountOnEnter, unmountOnExit } = this.props;
-
-    const stateActiveKey = this.state.activeKey;
-    const containerActiveKey = this.getContainerActiveKey();
-
-    const activeKey =
-      stateActiveKey != null ? stateActiveKey : containerActiveKey;
-    const exiting =
-      stateActiveKey != null && stateActiveKey !== containerActiveKey;
-
-    return {
-      $bs_tabContent: {
-        bsClass,
-        animation,
-        activeKey,
-        mountOnEnter,
-        unmountOnExit,
-        onPaneEnter: this.handlePaneEnter,
-        onPaneExited: this.handlePaneExited,
-        exiting
-      }
-    };
-  }
-
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (!nextProps.animation && this.state.activeChild) {
       this.setState({ activeKey: null, activeChild: null });
@@ -108,7 +66,7 @@ class TabContent extends React.Component {
   }
 
   getContainerActiveKey() {
-    const tabContainer = this.context.$bs_tabContainer;
+    const tabContainer = this.context;
     return tabContainer && tabContainer.activeKey;
   }
 
@@ -156,18 +114,40 @@ class TabContent extends React.Component {
       'unmountOnExit'
     ]);
 
+    const { bsClass, animation, mountOnEnter, unmountOnExit } = this.props;
+
+    const stateActiveKey = this.state.activeKey;
+    const containerActiveKey = this.getContainerActiveKey();
+
+    const activeKey =
+      stateActiveKey != null ? stateActiveKey : containerActiveKey;
+    const exiting =
+      stateActiveKey != null && stateActiveKey !== containerActiveKey;
+
+    const tabContentContext = {
+      bsClass,
+      animation,
+      activeKey,
+      mountOnEnter,
+      unmountOnExit,
+      onPaneEnter: this.handlePaneEnter,
+      onPaneExited: this.handlePaneExited,
+      exiting
+    };
+
     return (
-      <Component
-        {...elementProps}
-        className={classNames(className, prefix(bsProps, 'content'))}
-      />
+      <TabContentContext.Provider value={tabContentContext}>
+        <Component
+          {...elementProps}
+          className={classNames(className, prefix(bsProps, 'content'))}
+        />
+      </TabContentContext.Provider>
     );
   }
 }
 
 TabContent.propTypes = propTypes;
 TabContent.defaultProps = defaultProps;
-TabContent.contextTypes = contextTypes;
-TabContent.childContextTypes = childContextTypes;
+TabContent.contextType = TabContainerContext;
 
 export default setBsClass('tab', TabContent);

--- a/src/TabContentContext.js
+++ b/src/TabContentContext.js
@@ -1,0 +1,6 @@
+import React from 'react';
+
+const TabContentContext = React.createContext(undefined);
+TabContentContext.displayName = 'TabContentContext';
+
+export default TabContentContext;

--- a/src/TabPane.js
+++ b/src/TabPane.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import elementType from 'prop-types-extra/lib/elementType';
 import warning from 'warning';
 
+import TabContainerContext from './TabContainerContext';
+import TabContentContext from './TabContentContext';
 import {
   bsClass,
   getClassSet,
@@ -81,31 +83,6 @@ const propTypes = {
   unmountOnExit: PropTypes.bool
 };
 
-const contextTypes = {
-  $bs_tabContainer: PropTypes.shape({
-    getTabId: PropTypes.func,
-    getPaneId: PropTypes.func
-  }),
-  $bs_tabContent: PropTypes.shape({
-    bsClass: PropTypes.string,
-    animation: PropTypes.oneOfType([PropTypes.bool, elementType]),
-    activeKey: PropTypes.any,
-    mountOnEnter: PropTypes.bool,
-    unmountOnExit: PropTypes.bool,
-    onPaneEnter: PropTypes.func.isRequired,
-    onPaneExited: PropTypes.func.isRequired,
-    exiting: PropTypes.bool.isRequired
-  })
-};
-
-/**
- * We override the `<TabContainer>` context so `<Nav>`s in `<TabPane>`s don't
- * conflict with the top level one.
- */
-const childContextTypes = {
-  $bs_tabContainer: PropTypes.oneOf([null])
-};
-
 class TabPane extends React.Component {
   constructor(props, context) {
     super(props, context);
@@ -114,12 +91,6 @@ class TabPane extends React.Component {
     this.handleExited = this.handleExited.bind(this);
 
     this.in = false;
-  }
-
-  getChildContext() {
-    return {
-      $bs_tabContainer: null
-    };
   }
 
   componentDidMount() {
@@ -153,12 +124,12 @@ class TabPane extends React.Component {
       return this.props.animation;
     }
 
-    const tabContent = this.context.$bs_tabContent;
+    const tabContent = this.context;
     return tabContent && tabContent.animation;
   }
 
   handleEnter() {
-    const tabContent = this.context.$bs_tabContent;
+    const tabContent = this.context;
     if (!tabContent) {
       return;
     }
@@ -167,7 +138,7 @@ class TabPane extends React.Component {
   }
 
   handleExited() {
-    const tabContent = this.context.$bs_tabContent;
+    const tabContent = this.context;
     if (!tabContent) {
       return;
     }
@@ -177,7 +148,7 @@ class TabPane extends React.Component {
   }
 
   isActive() {
-    const tabContent = this.context.$bs_tabContent;
+    const tabContent = this.context;
     const activeKey = tabContent && tabContent.activeKey;
 
     return this.props.eventKey === activeKey;
@@ -187,7 +158,7 @@ class TabPane extends React.Component {
     return this.getAnimation() && this.isActive();
   }
 
-  render() {
+  renderPane(tabContainer) {
     const {
       eventKey,
       className,
@@ -202,10 +173,7 @@ class TabPane extends React.Component {
       ...props
     } = this.props;
 
-    const {
-      $bs_tabContent: tabContent,
-      $bs_tabContainer: tabContainer
-    } = this.context;
+    const tabContent = this.context;
 
     const [bsProps, elementProps] = splitBsPropsAndOmit(props, ['animation']);
 
@@ -281,10 +249,24 @@ class TabPane extends React.Component {
 
     return pane;
   }
+
+  render() {
+    // Read the `<TabContainer>` context so we can generate accessible ids, then
+    // override it with `null` so `<Nav>`s in `<TabPane>`s don't conflict with
+    // the top level one.
+    return (
+      <TabContainerContext.Consumer>
+        {tabContainer => (
+          <TabContainerContext.Provider value={null}>
+            {this.renderPane(tabContainer)}
+          </TabContainerContext.Provider>
+        )}
+      </TabContainerContext.Consumer>
+    );
+  }
 }
 
 TabPane.propTypes = propTypes;
-TabPane.contextTypes = contextTypes;
-TabPane.childContextTypes = childContextTypes;
+TabPane.contextType = TabContentContext;
 
 export default bsClass('tab-pane', TabPane);

--- a/test/OverlayTriggerSpec.js
+++ b/test/OverlayTriggerSpec.js
@@ -156,10 +156,6 @@ describe('<OverlayTrigger>', () => {
     ContextReader.contextTypes = contextTypes;
 
     class ContextHolder extends React.Component {
-      getChildContext() {
-        return { key: 'value' };
-      }
-
       render() {
         return (
           <OverlayTrigger trigger="click" overlay={<ContextReader />}>

--- a/test/index.js
+++ b/test/index.js
@@ -31,11 +31,6 @@ beforeEach(() => {
       return;
     }
 
-    if (msg.includes('childContextTypes') || msg.includes('contextTypes')) {
-      // @hmhealey These are removed in React 19
-      return;
-    }
-
     console.error.threw = true;
     throw new Error(msg);
   });


### PR DESCRIPTION
#### Summary
The next part of updating this for React 19 is to get rid of all usage of the now-deprecated legacy context API. Instead of using `contextTypes`/`childContextTypes`/`getChildContext`, we now use `React.createContext` to make provider components along with `useContext` in function components and the slightly different `contextType` in class components.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69835

